### PR TITLE
langchain-core v0.2.41

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "langchain-core" %}
-{% set version = "0.2.39" %}
+{% set version = "0.2.41" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/langchain_core-{{ version }}.tar.gz
-  sha256: 73d7b6f0b0212bc8069c3640d69e8d75faa51097784019ffa5c36c617c04acb0
+  sha256: bc12032c5a298d85be754ccb129bc13ea21ccb1d6e22f8d7ba18b8da64315bb5
 
 build:
   noarch: python


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

## Reviewer information

Note that the `v0.2` branch doesn't include v0.2.40, so the branch _appears_ to "skip" that release. [v0.2.40 was released in Conda Forge by merging the changes into a branch that was immediately deleted.](https://github.com/conda-forge/langchain-core-feedstock/pull/97)  I couldn't cherry-pick that commit into `v0.2` either, since it includes v0.3.0 in its commit history.

Link to `pyproject.toml` at v0.2.41: https://github.com/langchain-ai/langchain/blob/langchain-core%3D%3D0.2.41/libs/core/pyproject.toml

Git diff output:

```diff
% git diff langchain-core==0.2.40 langchain-core==0.2.41 -- libs/core/pyproject.toml
diff --git a/libs/core/pyproject.toml b/libs/core/pyproject.toml
index 44bc03978..364443590 100644
--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"

 [tool.poetry]
 name = "langchain-core"
-version = "0.2.40"
+version = "0.2.41"
 description = "Building applications with LLMs through composability"
 authors = []
 license = "MIT"
```